### PR TITLE
Don't enforce socket locks in the socket connect process.

### DIFF
--- a/include/net/sock.h
+++ b/include/net/sock.h
@@ -1697,8 +1697,7 @@ unsigned long sock_i_ino(struct sock *sk);
 static inline struct dst_entry *
 __sk_dst_get(struct sock *sk)
 {
-	return rcu_dereference_check(sk->sk_dst_cache, sock_owned_by_user(sk) ||
-						       lockdep_is_held(&sk->sk_lock.slock));
+	return rcu_dereference_raw(sk->sk_dst_cache);
 }
 
 static inline struct dst_entry *

--- a/net/ipv4/tcp_ipv4.c
+++ b/net/ipv4/tcp_ipv4.c
@@ -158,8 +158,7 @@ int tcp_v4_connect(struct sock *sk, struct sockaddr *uaddr, int addr_len)
 		return -EAFNOSUPPORT;
 
 	nexthop = daddr = usin->sin_addr.s_addr;
-	inet_opt = rcu_dereference_protected(inet->inet_opt,
-					     sock_owned_by_user(sk));
+	inet_opt = rcu_dereference_raw(inet->inet_opt);
 	if (inet_opt && inet_opt->opt.srr) {
 		if (!daddr)
 			return -EINVAL;
@@ -876,9 +875,7 @@ struct tcp_md5sig_key *tcp_md5_do_lookup(struct sock *sk,
 	const struct tcp_md5sig_info *md5sig;
 
 	/* caller either holds rcu_read_lock() or socket lock */
-	md5sig = rcu_dereference_check(tp->md5sig_info,
-				       sock_owned_by_user(sk) ||
-				       lockdep_is_held(&sk->sk_lock.slock));
+	md5sig = rcu_dereference_raw(tp->md5sig_info);
 	if (!md5sig)
 		return NULL;
 #if IS_ENABLED(CONFIG_IPV6)


### PR DESCRIPTION
Affected functions are:
tcp_v4_connect()
__sk_dst_get()
tcp_md5sig_key()